### PR TITLE
Add missing pydicom dependency in setup.py Closes #16

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
         'pytest',
         'tqdm',
         'transformers',
+        'pydicom'
     ],
     classifiers=[
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Add 'pydicom' to the list of install_requires in setup.py to ensure it is installed as a dependency.